### PR TITLE
Avoid undefined behavior: delete twice

### DIFF
--- a/tests/ee/anticache/anticache_eviction_manager_test.cpp
+++ b/tests/ee/anticache/anticache_eviction_manager_test.cpp
@@ -141,7 +141,7 @@ public:
     void cleanupTable()
     {
         //printf("delete from cleanupTable(): %p\n", m_table->getEvictedTable());
-        delete m_table->getEvictedTable();
+        //delete m_table->getEvictedTable();
         delete m_table;
     
     }


### PR DESCRIPTION
it's an undefined behavior and sometimes will cause eecheck fail.
