### PR TITLE
Bug fix for allocatortracker

### DIFF
--- a/src/ee/indexes/allocatortracker.h
+++ b/src/ee/indexes/allocatortracker.h
@@ -67,18 +67,6 @@ class AllocatorTracker : public std::allocator<ValueType> {
             *memory_size -= size * sizeof(ValueType);
         }
 
-        void construct(pointer __ptr, const ValueType& __val) {
-            new(__ptr) ValueType(__val);
-            VOLT_TRACE("construct +++++++ %p %lu.\n", __ptr, sizeof(ValueType));
-            VOLT_TRACE("%s\n", typeid(ValueType).name());
-            *memory_size += sizeof(ValueType);
-        }
-
-        void destroy(pointer __ptr) {
-            VOLT_TRACE("-+-+-+- %08x.\n", __ptr);
-            __ptr->~ValueType();
-            *memory_size -= sizeof(ValueType);
-        }
 };
 
 } // namespace h_index

--- a/third_party/cpp/stx/btree.h
+++ b/third_party/cpp/stx/btree.h
@@ -1489,16 +1489,14 @@ private:
             leaf_node *ln = static_cast<leaf_node*>(n);
             typename leaf_node::alloc_type a(leaf_node_allocator());
             a.destroy(ln);
-            //a.deallocate(ln, 1);
-            free(ln);
+            a.deallocate(ln, 1);
             m_stats.leaves--;
         }
         else {
             inner_node *in = static_cast<inner_node*>(n);
             typename inner_node::alloc_type a(inner_node_allocator());
             a.destroy(in);
-            //a.deallocate(in, 1);
-            free(in);
+            a.deallocate(in, 1);
             m_stats.innernodes--;
         }
     }


### PR DESCRIPTION
There are two functions that should not be overridden in the allocator. Thanks @huanchenz for pointing out the abnormal memory stats for me.