### PR TITLE
Two Anticaching Changes

### DIFF
--- a/src/ee/anticache/AntiCacheDB.cpp
+++ b/src/ee/anticache/AntiCacheDB.cpp
@@ -57,7 +57,7 @@ AntiCacheDB::AntiCacheDB(ExecutorContext *ctx, std::string db_dir, long blockSiz
     { 
         // MJG: TODO: HACK: Come up with a better way to make a maxsize when one isn't given
         if (maxSize == -1) {
-            m_maxDBSize = 1000*blockSize;
+            m_maxDBSize = 5000*blockSize;
         } else {
             m_maxDBSize = maxSize;
         }

--- a/src/ee/anticache/AntiCacheEvictionManager.cpp
+++ b/src/ee/anticache/AntiCacheEvictionManager.cpp
@@ -685,6 +685,16 @@ bool AntiCacheEvictionManager::evictBlockToDisk(PersistentTable *table, const lo
                                     num_tuples_evicted,
                                     blockdata,
                                     blocksize);
+            
+            // MJG: We need to check whether we're reusing a blockID.
+
+            bool reused = table->removeUnevictedBlockID(block_id);
+            if (reused) {
+                VOLT_INFO("Reusing block_id %x, should be safe", block_id);
+            } else {
+                VOLT_DEBUG("First time block_id %x has been used", block_id);
+            }
+
             needs_flush = true;
 
             // store pointer to AntiCacheDB associated with this block

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -329,7 +329,7 @@ void PersistentTable::insertUnevictedBlockID(std::pair<int32_t,int32_t> pair)
 }
 
 bool PersistentTable::removeUnevictedBlockID(int32_t blockId) {
-    if (isAlreadyUnevicted(blockId)) {
+    if (isAlreadyUnEvicted(blockId)) {
         VOLT_INFO("Reusing blockID %x, so we need to remove it from list", blockId);
         m_unevictedBlockIDs.erase(m_unevictedBlockIDs.find(blockId));
         return true;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -328,6 +328,15 @@ void PersistentTable::insertUnevictedBlockID(std::pair<int32_t,int32_t> pair)
     m_unevictedBlockIDs.insert(pair);
 }
 
+bool PersistentTable::removeUnevictedBlockID(int32_t blockId) {
+    if (isAlreadyUnevicted(blockId)) {
+        VOLT_INFO("Reusing blockID %x, so we need to remove it from list", blockId);
+        m_unevictedBlockIDs.erase(m_unevictedBlockIDs.find(blockId));
+        return true;
+    }
+    return false;
+}
+
 std::vector<char*> PersistentTable::getUnevictedBlocks()
 {
     return m_unevictedBlocks;

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -297,6 +297,7 @@ class PersistentTable : public Table {
     void setBytesWritten(int64_t bytesWritten);
     voltdb::TableTuple * getTempTarget1();
     void insertUnevictedBlockID(std::pair<int32_t,int32_t>);
+    bool removeUnevictedBlockID(int32_t blockId);
     void insertUnevictedBlock(char* unevicted_tuples);
     void insertTupleOffset(int32_t tuple_offset);
     bool isAlreadyUnEvicted(int32_t blockId);


### PR DESCRIPTION
This has two important changes. 

1. Allow the reuse of blockIDs by NVMAntiCacheDB. If this is not fixed as block IDs get reused, their contents will not be merged correctly. 
        a. Fixed by adding a function to remove unevicted block IDs.
        b. Added functionality to check whether a block ID is being reused in ACEM
2. Increase the default database size from 1000 to 5000 blocks. 1000 blocks was causing an error when large benchmarks were being run. 