### PR TITLE
Four bugfixes

### DIFF
--- a/src/ee/anticache/AntiCacheDB.cpp
+++ b/src/ee/anticache/AntiCacheDB.cpp
@@ -78,7 +78,7 @@ AntiCacheBlock* AntiCacheDB::getLRUBlock() {
         lru_block_id = m_block_lru.front();
         //m_block_lru.pop_front();
         lru_block = readBlock(lru_block_id);
-        m_totalBlocks--;
+        //m_totalBlocks--;
         return lru_block;
     }
 }

--- a/src/ee/anticache/AntiCacheEvictionManager.cpp
+++ b/src/ee/anticache/AntiCacheEvictionManager.cpp
@@ -547,11 +547,7 @@ bool AntiCacheEvictionManager::evictBlockToDisk(PersistentTable *table, const lo
     VOLT_DEBUG("%s Table Schema:\n%s",
               evictedTable->name().c_str(), evictedTable->schema()->debug().c_str());
 
-    // get the AntiCacheDB instance from the executorContext
-    // For now use the single AntiCacheDB from PersistentTable but in the future, this 
-    // method to get the AntiCacheDB will have to choose which AntiCacheDB from to
-    // evict to
-    AntiCacheDB* antiCacheDB = table->getAntiCacheDB(chooseDB(block_size, m_migrate));
+    AntiCacheDB* antiCacheDB;
     int tuple_length = -1;
     bool needs_flush = false;
 
@@ -569,6 +565,11 @@ bool AntiCacheEvictionManager::evictBlockToDisk(PersistentTable *table, const lo
     for(int i = 0; i < num_blocks; i++)
     {
 
+        // get the AntiCacheDB instance from the executorContext
+        // For now use the single AntiCacheDB from PersistentTable but in the future, this 
+        // method to get the AntiCacheDB will have to choose which AntiCacheDB from to
+        // evict to
+        antiCacheDB = table->getAntiCacheDB(chooseDB(block_size, m_migrate));
         // get the LS16B and send that to the antiCacheDB
         int16_t _block_id = antiCacheDB->nextBlockId();
 
@@ -655,7 +656,7 @@ bool AntiCacheEvictionManager::evictBlockToDisk(PersistentTable *table, const lo
                    table->name().c_str(), num_tuples_evicted);
         
         // Only write out a bock if there are tuples in it
-        if (num_tuples_evicted >= 0) {
+        if (num_tuples_evicted > 0) {
             std::vector<int> numTuples;
             numTuples.push_back(num_tuples_evicted);
             block.writeHeader(numTuples);
@@ -775,7 +776,7 @@ bool AntiCacheEvictionManager::evictBlockToDiskInBatch(PersistentTable *table, P
  //             evictedTable->name().c_str(), evictedTable->schema()->debug().c_str());
 
     // get the AntiCacheDB instance from the executorContext
-    AntiCacheDB* antiCacheDB = table->getAntiCacheDB(chooseDB(block_size, m_migrate));
+    AntiCacheDB* antiCacheDB;
     int tuple_length = -1;
     bool needs_flush = false;
 
@@ -815,6 +816,7 @@ bool AntiCacheEvictionManager::evictBlockToDiskInBatch(PersistentTable *table, P
    //     this->printLRUChain(table, 4, true);
     //    VOLT_INFO("Printing child's LRU chain");
    //     this->printLRUChain(childTable, 4, true);
+        antiCacheDB = table->getAntiCacheDB(chooseDB(block_size, m_migrate));
         // get a unique block id from the executorContext
         int16_t _block_id = antiCacheDB->nextBlockId();
         int32_t block_id = ((antiCacheDB->getACID() << 16) | _block_id);

--- a/src/frontend/edu/brown/hstore/AntiCacheManager.java
+++ b/src/frontend/edu/brown/hstore/AntiCacheManager.java
@@ -483,7 +483,7 @@ public class AntiCacheManager extends AbstractProcessingRunnable<AntiCacheManage
          */
         return  totalEvictableSizeKb >= (hstore_conf.site.anticache_block_size / 1024) &&
                 this.pendingEvictions == 0 &&
-                totalDataSize > hstore_conf.site.anticache_threshold_mb &&
+                totalActiveDataSize > hstore_conf.site.anticache_threshold_mb &&
 //                totalEvictedMB < (totalDataSize * hstore_conf.site.anticache_threshold) &&
                 totalBlocksEvicted < hstore_conf.site.anticache_max_evicted_blocks;
     }


### PR DESCRIPTION
1. AntiCacheManager was using total data size to evict data, not active,
   in-memory data. This means that it would continue to evict even when
   memory was practically empty.
2. Fixes a problem where blcoks with zero tuples were being written out. This
   could occur when, say 200 blcoks would be queued for eviction, but only 50
   blocks worth of data could be evicted. Then it would still evict 150 empty
   blocks due to an = sign.
3. Fixed a double delete of blockIDs when migrating that caused a problem due
   to running out of room.
4. Moved the chooseDB selection of AntiCacheDBs to inside the loop of batching
   evictions. By having it outside of the loop, when a tier would fill, it
   wouldn't trigger a migration, only a FullBackingStoreException and failure.