### PR TITLE
Duplicate subexpressions in DesignerHints.java

### DIFF
--- a/src/frontend/edu/brown/designer/DesignerHints.java
+++ b/src/frontend/edu/brown/designer/DesignerHints.java
@@ -605,7 +605,7 @@ public class DesignerHints implements Cloneable, JSONSerializable {
         }
 
         // Target PartitionPlan
-        if (this.target_plan_path != null && this.target_plan_path != null) {
+        if (this.target_plan_path != null) {
             if (debug.val)
                 LOG.debug("Loading in target PartitionPlan from '" + this.target_plan_path + "'");
             this.target_plan = new PartitionPlan();


### PR DESCRIPTION
`this.target_plan_path != null` is repeated.